### PR TITLE
feat: add apis to load configuration from json

### DIFF
--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -54,6 +54,15 @@ class Highlighter {
     }
   }
 
+  /// Adds a custom language to the list of languages.
+  ///
+  /// Format in json string and follow the textmate bundle format.
+  ///
+  /// This must be called before creating any [Highlighter]s.
+  static void addLanguage(String name, String json) {
+    _cache.putIfAbsent(name, () => Grammar.fromJson(jsonDecode(json)));
+  }
+
   /// The language of this [Highlighter].
   final String language;
 
@@ -175,6 +184,14 @@ class HighlighterTheme {
   final _scopes = <String, TextStyle>{};
 
   HighlighterTheme._({required TextStyle wrapper}) : _wrapper = wrapper;
+
+  /// load a [HighlighterTheme] from a [json] string.
+  factory HighlighterTheme.fromConfiguration(
+      String json, TextStyle defaultStyle) {
+    final theme = HighlighterTheme._(wrapper: defaultStyle);
+    theme._parseTheme(json);
+    return theme;
+  }
 
   /// Loads the default theme for the given [brightness].
   static Future<HighlighterTheme> loadForBrightness(

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -55,9 +55,7 @@ class Highlighter {
   }
 
   /// Adds a custom language to the list of languages.
-  ///
-  /// Format in json string and follow the textmate bundle format.
-  ///
+  /// Associates a language [name] with a TextMate formatted [json] definition.
   /// This must be called before creating any [Highlighter]s.
   static void addLanguage(String name, String json) {
     _cache.putIfAbsent(name, () => Grammar.fromJson(jsonDecode(json)));

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -183,7 +183,7 @@ class HighlighterTheme {
 
   HighlighterTheme._({required TextStyle wrapper}) : _wrapper = wrapper;
 
-  /// Load a [HighlighterTheme] from a [json] string.
+  /// Load a [HighlighterTheme] from a JSON string.
   factory HighlighterTheme.fromConfiguration(
     String json,
     TextStyle defaultStyle,

--- a/lib/src/highlighter.dart
+++ b/lib/src/highlighter.dart
@@ -185,9 +185,11 @@ class HighlighterTheme {
 
   HighlighterTheme._({required TextStyle wrapper}) : _wrapper = wrapper;
 
-  /// load a [HighlighterTheme] from a [json] string.
+  /// Load a [HighlighterTheme] from a [json] string.
   factory HighlighterTheme.fromConfiguration(
-      String json, TextStyle defaultStyle) {
+    String json,
+    TextStyle defaultStyle,
+  ) {
     final theme = HighlighterTheme._(wrapper: defaultStyle);
     theme._parseTheme(json);
     return theme;


### PR DESCRIPTION
```dart
  // some language textmate grammar json string
  const fooJson = "......";
  Highlighter.addLanguage("foo", fooJson);

  // some theme configuration json string
  const barTheme = "......";
  final theme = HighlighterTheme.fromConfiguration(
      barTheme, const TextStyle(color: Colors.black));

  final fooHighligher = Highlighter(language: 'foo', theme: theme);

  const fooCode = "......";
  final span = fooHighligher.highlight(fooCode);
```