### PR TITLE
feat: Add Serverpod protocol grammar

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,14 +19,24 @@ const _code = '''class MyApp extends StatelessWidget {
   }
 }''';
 
+const _serverpodYaml = '''
+class: Customer
+table: customer
+fields:
+  name: String
+  orders: List<Order>?, relation
+''';
+
 late final Highlighter _dartLightHighlighter;
 late final Highlighter _dartDarkHighlighter;
+late final Highlighter _serverpodProtocolLightYamlHighlighter;
+late final Highlighter _serverpodProtocolDarkYamlHighlighter;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Initialize the highlighter.
-  await Highlighter.initialize(['dart', 'yaml', 'sql']);
+  await Highlighter.initialize(['dart', 'yaml', 'sql', 'serverpod_protocol']);
 
   // Load the default light theme and create a highlighter.
   var lightTheme = await HighlighterTheme.loadLightTheme();
@@ -34,11 +44,19 @@ void main() async {
     language: 'dart',
     theme: lightTheme,
   );
+  _serverpodProtocolLightYamlHighlighter = Highlighter(
+    language: 'serverpod_protocol',
+    theme: lightTheme,
+  );
 
   // Load the default dark theme and create a highlighter.
   var darkTheme = await HighlighterTheme.loadDarkTheme();
   _dartDarkHighlighter = Highlighter(
     language: 'dart',
+    theme: darkTheme,
+  );
+  _serverpodProtocolDarkYamlHighlighter = Highlighter(
+    language: 'serverpod_protocol',
     theme: darkTheme,
   );
 
@@ -87,6 +105,30 @@ class MyHomePage extends StatelessWidget {
             child: Text.rich(
               // Highlight the code.
               _dartDarkHighlighter.highlight(_code),
+              style: GoogleFonts.jetBrainsMono(
+                fontSize: 14,
+                height: 1.3,
+              ),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(16),
+            color: Colors.white,
+            child: Text.rich(
+              // Highlight the code.
+              _serverpodProtocolLightYamlHighlighter.highlight(_serverpodYaml),
+              style: GoogleFonts.jetBrainsMono(
+                fontSize: 14,
+                height: 1.3,
+              ),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(16),
+            color: Colors.black,
+            child: Text.rich(
+              // Highlight the code.
+              _serverpodProtocolDarkYamlHighlighter.highlight(_serverpodYaml),
               style: GoogleFonts.jetBrainsMono(
                 fontSize: 14,
                 height: 1.3,

--- a/grammars/serverpod_protocol.json
+++ b/grammars/serverpod_protocol.json
@@ -1,0 +1,201 @@
+{
+    "name": "ServerpodProtocol",
+    "scopeName": "source.serverpod",
+    "patterns": [
+      {
+        "include": "#fields"
+      },
+      {
+        "include": "#indexes"
+      },
+      {
+        "include": "#comments"
+      },
+      {
+        "name": "entity.name.tag.yaml",
+        "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
+      },
+      {
+        "include": "#basic_value_types"
+      },
+      {
+        "name": "entity.name.type.yaml",
+        "match": "\\b(?<=(class|exception|enum):\\s+)([a-zA-Z0-9_<>\\?,\\s]+>)(?=\\??,|\\s|$)"
+      },
+      {
+        "name": "entity.name.type.yaml",
+        "match": "\\b(?<=(class|exception|enum):\\s+)([a-zA-Z0-9_]+)(?=\\??$|\\??,|\\s|$)"
+      },
+      {
+        "name": "string.unquoted.yaml",
+        "match": "\\b(?<=:\\s*)([a-zA-Z0-9_-]+)\\b"
+      }
+    ],
+    "repository": {
+      "basic_value_types": {
+        "patterns": [
+          {
+            "name": "constant.numeric.yaml",
+            "match": "\\b-?[0-9]+(\\.[0-9]*)?(e-?[0-9]+)?\\b"
+          },
+          {
+            "name": "constant.language.boolean.yaml",
+            "match": "\\b(true|false)\\b"
+          },
+          {
+            "name": "constant.language.null.yaml",
+            "match": "\\bnull\\b"
+          }
+        ]
+      },
+      "fields": {
+        "begin": "(fields)(:)(\\s*$)",
+        "beginCaptures": {
+          "1": {
+            "name": "entity.name.tag.yaml"
+          },
+          "2": {
+            "name": "punctuation.separator.mapping.key-value.yaml"
+          }
+        },
+        "end": "(?=^\\S)",
+        "patterns": [
+          {
+            "include": "#comments"
+          },
+          {
+            "name": "keyword.operator.assignment.yaml",
+            "match": "="
+          },
+          {
+            "name": "punctuation.separator.comma.yaml",
+            "match": ","
+          },
+          {
+            "include": "#params"
+          },
+          {
+            "include": "#basic_value_types"
+          },
+          {
+            "name": "string.quoted.double.yaml",
+            "match": "\\b(?<==)([a-zA-Z0-9_-]+)(?=,|\\))"
+          },
+          {
+            "name": "string.unquoted.yaml",
+            "match": "\\b(?<=\\s*=\\s*)([a-zA-Z0-9_-]+)\\b"
+          },
+          {
+            "name": "entity.name.function.yaml",
+            "match": "\\b([a-zA-Z0-9_-]+)(?=\\()"
+          },
+          {
+            "name": "entity.name.tag.yaml",
+            "match": "\\b(!?[a-zA-Z0-9_-]+)(?=\\s*[:=]|$)"
+          },
+          {
+            "name": "entity.name.tag.yaml",
+            "match": "\\b(!?[a-zA-Z0-9_-]+)(?=\\s*[,\\)]|$)"
+          },
+          {
+            "begin": "(:\\s*)([^\\s<]*)(<)",
+            "beginCaptures": {
+              "1": {
+                "name": "punctuation.separator.mapping.key-value.yaml"
+              },
+              "2": {
+                "name": "entity.name.type.yaml"
+              },
+              "3": {
+                "name": "punctuation.definition.type.begin.yaml"
+              }
+            },
+            "end": "(>)",
+            "endCaptures": {
+              "1": {
+                "name": "punctuation.definition.type.end.yaml"
+              }
+            },
+            "patterns": [
+              {
+                "match": "[^,>\\s?]+",
+                "name": "entity.name.type.yaml"
+              }
+            ]
+          },
+          {
+            "match": "(:\\s*)([^,<\\s?]+)",
+            "captures": {
+              "1": {
+                "name": "punctuation.separator.mapping.key-value.yaml"
+              },
+              "2": {
+                "name": "entity.name.type.yaml"
+              }
+            }
+          },
+          {
+            "name": "string.unquoted.yaml",
+            "match": "\\b(?<=:\\s*|,\\s*)([a-zA-Z0-9_-]+)\\b"
+          }
+        ]
+      },
+      "indexes": {
+        "begin": "(indexes)(:)(\\s*$)",
+        "beginCaptures": {
+          "1": {
+            "name": "entity.name.tag.yaml"
+          },
+          "2": {
+            "name": "punctuation.separator.mapping.key-value.yaml"
+          }
+        },
+        "end": "(?=^\\S)",
+        "patterns": [
+          {
+            "include": "#params"
+          },
+          {
+            "include": "#basic_value_types"
+          },
+          {
+            "name": "entity.name.tag.yaml",
+            "match": "\\b([a-zA-Z0-9_-]+)(?=\\s*:)"
+          },
+          {
+            "name": "string.unquoted.yaml",
+            "match": "\\b(?<=:\\s*|,\\s*)([a-zA-Z0-9_-]+)\\b"
+          }
+        ]
+      },
+      "params": {
+        "patterns": [
+          {
+            "name": "entity.name.variable.yaml",
+            "match": "(?<=^\\s{2}|\\t)\\b([a-zA-Z0-9_]+)(?=:\\s)"
+          }
+        ]
+      },
+      "comments": {
+        "patterns": [
+          {
+            "match": "(###.*$)",
+            "captures": {
+              "0": {
+                "name": "comment.block.documentation.yaml"
+              }
+            }
+          },
+          {
+            "match": "(#.*$)",
+            "captures": {
+              "0": {
+                "name": "comment.line.yaml"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "uuid": "123e4567-e89b-12d3-a456-426655440000"
+  }


### PR DESCRIPTION
Adds the syntax used for serverpod protocol files from the serverpod main repo.

Not sure what the naming convention should be when the grammar is very specific.

We can skip the second commit if we don't want it added to the example.

<img width="788" alt="Screenshot 2023-12-01 at 09 23 41" src="https://github.com/serverpod/syntax_highlight/assets/137198655/77951b73-a669-473c-9fbb-8dab1eb24022">
