### PR TITLE
fix: fix a json grammar error

### DIFF
--- a/grammars/json.json
+++ b/grammars/json.json
@@ -78,7 +78,7 @@
 			"name": "constant.language.json"
 		},
 		"number": {
-			"match": "-?(?:0|[1-9]\\d*)\n(?:\n(?:\n\\.\\d+)?\n(?:\n[eE][+-]?\\d+)?)?",
+			"match": "-?(?:0|[1-9]\\d*)(?:(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)?",
 			"name": "constant.numeric.json"
 		},
 		"object": {


### PR DESCRIPTION
remove the invalid `\n` in json grammar
Left side shows the old syntax, right side shows the corrected version.
![json](https://github.com/user-attachments/assets/6c8ab79c-4057-411c-aa85-54eeecc705d3)
